### PR TITLE
Add Facility and Role as constants rather than database models

### DIFF
--- a/pkg/constants/facility.go
+++ b/pkg/constants/facility.go
@@ -1,0 +1,71 @@
+package constants
+
+type Facility string
+
+const (
+	// Special Facilities
+	AcademyFacility      Facility = "ZAE"
+	HeadquartersFacility Facility = "ZHQ"
+	NonMemberFacility    Facility = "ZZN"
+	InactiveFacility     Facility = "ZZI"
+
+	// ARTCC Facilities
+	AlbuquerqueFacility  Facility = "ZAB"
+	AnchorageFacility    Facility = "ZAN"
+	AtlantaFacility      Facility = "ZTL"
+	BostonFacility       Facility = "ZBW"
+	ChicagoFacility      Facility = "ZAU"
+	ClevelandFacility    Facility = "ZOB"
+	DenverFacility       Facility = "ZDV"
+	FortWorthFacility    Facility = "ZFW"
+	HonoluluFacility     Facility = "HCF"
+	HoustonFacility      Facility = "ZHU"
+	IndianapolisFacility Facility = "ZID"
+	JacksonvilleFacility Facility = "ZJX"
+	KansasCityFacility   Facility = "ZKC"
+	LosAngelesFacility   Facility = "ZLA"
+	MemphisFacility      Facility = "ZME"
+	MiamiFacility        Facility = "ZMA"
+	MinneapolisFacility  Facility = "ZMP"
+	NewYorkFacility      Facility = "ZNY"
+	OaklandFacility      Facility = "ZOA"
+	SaltLakeFacility     Facility = "ZLC"
+	SeattleFacility      Facility = "ZSE"
+	WashingtonFacility   Facility = "ZDC"
+)
+
+var (
+	FacilityDisplayNameMap = map[Facility]string{
+		AcademyFacility:      "Academy",
+		HeadquartersFacility: "Headquarters",
+		NonMemberFacility:    "Non-Member",
+		InactiveFacility:     "Inactive",
+
+		AlbuquerqueFacility:  "Albuquerque ARTCC",
+		AnchorageFacility:    "Anchorage ARTCC",
+		AtlantaFacility:      "Atlanta ARTCC",
+		BostonFacility:       "Boston ARTCC",
+		ChicagoFacility:      "Chicago ARTCC",
+		ClevelandFacility:    "Cleveland ARTCC",
+		DenverFacility:       "Denver ARTCC",
+		FortWorthFacility:    "Fort Worth ARTCC",
+		HonoluluFacility:     "Honolulu Control Facility",
+		HoustonFacility:      "Houston ARTCC",
+		IndianapolisFacility: "Indianapolis ARTCC",
+		JacksonvilleFacility: "Jacksonville ARTCC",
+		KansasCityFacility:   "Kansas City ARTCC",
+		LosAngelesFacility:   "Los Angeles ARTCC",
+		MemphisFacility:      "Memphis ARTCC",
+		MiamiFacility:        "Miami ARTCC",
+		MinneapolisFacility:  "Minneapolis ARTCC",
+		NewYorkFacility:      "New York ARTCC",
+		OaklandFacility:      "Oakland ARTCC",
+		SaltLakeFacility:     "Salt Lake ARTCC",
+		SeattleFacility:      "Seattle ARTCC",
+		WashingtonFacility:   "Washington, D.C. ARTCC",
+	}
+)
+
+func (f Facility) DisplayName() string {
+	return FacilityDisplayNameMap[f]
+}

--- a/pkg/constants/role.go
+++ b/pkg/constants/role.go
@@ -1,0 +1,115 @@
+package constants
+
+import "slices"
+
+type Role string
+
+const (
+	AirTrafficManagerRole       Role = "ATM"
+	DeputyAirTrafficManagerRole Role = "DATM"
+	TrainingAdministratorRole   Role = "TA"
+	EventCoordinatorRole        Role = "EC"
+	FacilityEngineerRole        Role = "FE"
+	WebMasterRole               Role = "WM"
+	InstructorRole              Role = "INS"
+	MentorRole                  Role = "MTR"
+	DeveloperTeamRole           Role = "DEVELOPER"
+	DivisionStaffRole           Role = "DIVISION_STAFF"
+	DivisionManagementRole      Role = "DIVISION_MANAGEMENT"
+	AceTeamRole                 Role = "ACE"
+	NTMSRole                    Role = "NTMS"
+	NTMTRole                    Role = "NTMT"
+	SocialMediaTeam             Role = "SMT"
+	EmailUser                   Role = "EMAIL"
+	TrainingContentTeam         Role = "TCT"
+	AcademyMaterialEditor       Role = "CBT"
+	FacilityMaterialEditor      Role = "FACCBT"
+)
+
+var (
+	RoleDisplayNameMap = map[Role]string{
+		AirTrafficManagerRole:       "Air Traffic Manager",
+		DeputyAirTrafficManagerRole: "Deputy Air Traffic Manager",
+		TrainingAdministratorRole:   "Training Administrator",
+		EventCoordinatorRole:        "Event Coordinator",
+		FacilityEngineerRole:        "Facility Engineer",
+		WebMasterRole:               "Webmaster",
+		InstructorRole:              "Instructor",
+		MentorRole:                  "Mentor",
+		DeveloperTeamRole:           "Developer Team",
+		DivisionStaffRole:           "Division Staff",
+		DivisionManagementRole:      "Division Management",
+		AceTeamRole:                 "ACE Team",
+		NTMSRole:                    "National Traffic Management Supervisor",
+		NTMTRole:                    "National Traffic Management Supervisor",
+		SocialMediaTeam:             "Social Media Team",
+		EmailUser:                   "Email User",
+		TrainingContentTeam:         "Training Content Team",
+		AcademyMaterialEditor:       "Academy Material Editor (Academy)",
+		FacilityMaterialEditor:      "Academy Material Editor (Facility)",
+	}
+	FacilityBasedRoles = []Role{
+		AirTrafficManagerRole,
+		DeputyAirTrafficManagerRole,
+		TrainingAdministratorRole,
+		EventCoordinatorRole,
+		FacilityEngineerRole,
+		WebMasterRole,
+		InstructorRole,
+		MentorRole,
+		FacilityMaterialEditor,
+		EmailUser,
+	}
+	FacilityStaffRoles = []Role{
+		AirTrafficManagerRole,
+		DeputyAirTrafficManagerRole,
+		TrainingAdministratorRole,
+		EventCoordinatorRole,
+		FacilityEngineerRole,
+		WebMasterRole,
+	}
+	FacilityManagementRoles = []Role{
+		AirTrafficManagerRole,
+		DeputyAirTrafficManagerRole,
+		TrainingAdministratorRole,
+	}
+	// FacilityManagedRoles can be assigned by AirTrafficManagerRole / DeputyAirTrafficManagerRole
+	FacilityManagedRoles = []Role{
+		EventCoordinatorRole,
+		FacilityEngineerRole,
+		WebMasterRole,
+		MentorRole,
+		FacilityMaterialEditor,
+		EmailUser,
+	}
+
+	// AssignmentRestrictedRoles can only be assigned by DivisionManagementRole
+	AssignmentRestrictedRoles = []Role{
+		DivisionStaffRole,
+		DivisionManagementRole,
+	}
+)
+
+func (r Role) DisplayName() string {
+	return RoleDisplayNameMap[r]
+}
+
+func (r Role) isFacilityBased() bool {
+	return slices.Contains(FacilityBasedRoles, r)
+}
+
+func (r Role) isFacilityStaff() bool {
+	return slices.Contains(FacilityStaffRoles, r)
+}
+
+func (r Role) isFacilityManagement() bool {
+	return slices.Contains(FacilityManagementRoles, r)
+}
+
+func (r Role) isFacilityManaged() bool {
+	return slices.Contains(FacilityManagedRoles, r)
+}
+
+func (r Role) isAssignmentRestricted() bool {
+	return slices.Contains(AssignmentRestrictedRoles, r)
+}


### PR DESCRIPTION
Consider doing static data (that will only change with functionality changes to the code) as constant types like this instead of as database records. This way the different roles can be easily referenced without having "magic strings" scattered throughout the code.